### PR TITLE
switch to @switch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
-MLStyle = "0.3"
+MLStyle = "0.4"
 TupleTools = "1.2"
 DataStructures = "0.17"
 julia = "1.3,1.4"


### PR DESCRIPTION
@thautwarm 

The time of `using` and running tests
## Before
**v0.3.1**
```bash
$ time julia test/runtests.jl
julia test/runtests.jl  51.12s user 0.44s system 100% cpu 51.324 total
```

```julia
julia> @time using NiLang
  1.105406 seconds (980.37 k allocations: 58.199 MiB, 2.85% gc time)
```

**master branch**

```bash
$ time julia test/runtests.jl
julia test/runtests.jl  51.13s user 0.45s system 100% cpu 51.370 total
```
```julia
julia> @time using NiLang
  1.064438 seconds (1.05 M allocations: 62.084 MiB, 2.77% gc time)
```

## After changing `@match` to `@switch`
```bash
$ time julia test/runtests.jl
julia test/runtests.jl  49.64s user 0.53s system 100% cpu 49.904 total
```

```julia
julia> @time using NiLang
  1.099745 seconds (1.05 M allocations: 62.547 MiB, 2.68% gc time)
```

Have I benchmarked correctly?
The code style looks much better. But I will not merge this PR immediately, because using `@switch` is not compatible with other packages that rely on MLStyle v0.3. e.g. YaoBlocks. I need to update and tag YaoBlocks first.