### PR TITLE
Allow nothing

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -132,8 +132,10 @@ function compile_ex(m::Module, ex, info)
                 :(wait($res))
             )
         end
+        :(nothing) => ex
+        ::Nothing => ex
         ::LineNumberNode => ex
-        _ => error("statement is not supported for invertible lang! got $ex")
+        _ => error("statement $ex is not supported for invertible lang! got $ex")
     end
 end
 

--- a/src/dualcode.jl
+++ b/src/dualcode.jl
@@ -85,6 +85,7 @@ function dual_ex(m::Module, ex)
         :(@avx $line $subex) => Expr(:macrocall, Symbol("@avx"), line, dual_ex(m, subex))
         :(@invcheckoff $line $subex) => Expr(:macrocall, Symbol("@invcheckoff"), line, dual_ex(m, subex))
         :(begin $(body...) end) => Expr(:block, dual_body(m, body)...)
+        :(nothing) => ex
         ::LineNumberNode => ex
         ::Nothing => ex
         :() => ex

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -148,6 +148,7 @@ function precom_ex(m::Module, ex, info)
         :(~$expr) => dual_ex(m, precom_ex(m, expr, info))
         :($f($(args...))) => :($f($(args...)))
         :($f.($(args...))) => :($f.($(args...)))
+        :(nothing) => ex
         Expr(:macrocall, _...) => precom_ex(m, macroexpand(m, ex), info)
         ::LineNumberNode => ex
         ::Nothing => ex

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -611,3 +611,10 @@ end
     end
     @test f(3.0) == 3.0
 end
+
+@testset "allow nothing pass" begin
+    @i function f(x)
+        nothing
+    end
+    @test f(2) == 2
+end


### PR DESCRIPTION
Allow nothing to pass so that to following example works

```julia
julia> using Base.Cartesian, NiLang

julia> @i function f1(A!, B, C)
           @nloops 3 i A! begin
               @nref(3, A!, i) += @nref(3, B, i)
               @nref(3, A!, i) += @nref(3, C, i)
           end
       end

julia> A = randn(2, 2, 2);

julia> B, C = copy(A), copy(A);

julia> f1(A, B, C)
```