### PR TITLE
Composite functions and fix unary broadcasting

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -139,7 +139,9 @@ struct Inv{FT} <: Function
     f::FT
 end
 Inv(f::Inv) = f.f
-Base.:~(f::Base.ComposedFunction) = (~(f.inner)) ∘ (~(f.outer))
+@static if VERSION >= v"1.6"
+    Base.:~(f::Base.ComposedFunction) = (~(f.inner)) ∘ (~(f.outer))
+end
 Base.:~(f::Function) = Inv(f)
 Base.:~(::Type{Inv{T}}) where T = T  # for type, it is a destructor
 Base.:~(::Type{T}) where T = Inv{T}  # for type, it is a destructor

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -139,6 +139,7 @@ struct Inv{FT} <: Function
     f::FT
 end
 Inv(f::Inv) = f.f
+Base.:~(f::ComposedFunction) = (~(f.inner)) ∘ (~(f.outer))
 Base.:~(f::Function) = Inv(f)
 Base.:~(::Type{Inv{T}}) where T = T  # for type, it is a destructor
 Base.:~(::Type{T}) where T = Inv{T}  # for type, it is a destructor

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -139,7 +139,7 @@ struct Inv{FT} <: Function
     f::FT
 end
 Inv(f::Inv) = f.f
-Base.:~(f::ComposedFunction) = (~(f.inner)) ∘ (~(f.outer))
+Base.:~(f::Base.ComposedFunction) = (~(f.inner)) ∘ (~(f.outer))
 Base.:~(f::Function) = Inv(f)
 Base.:~(::Type{Inv{T}}) where T = T  # for type, it is a destructor
 Base.:~(::Type{T}) where T = Inv{T}  # for type, it is a destructor

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -76,11 +76,21 @@ function _zero(d::T) where {A,B,T<:Dict{A,B}}
     Dict{A,B}([x=>zero(y) for (x,y) in d])
 end
 
-@generated function chfield(x, ::Val{FIELD}, xval) where FIELD
-    if x.mutable
-        Expr(:block, :(x.$FIELD = xval), :x)
-    else
-        :(@with x.$FIELD = xval)
+@static if VERSION > v"1.6.100"
+    @generated function chfield(x, ::Val{FIELD}, xval) where FIELD
+        if ismutabletype(x)
+            Expr(:block, :(x.$FIELD = xval), :x)
+        else
+            :(@with x.$FIELD = xval)
+        end
+    end
+else
+    @generated function chfield(x, ::Val{FIELD}, xval) where FIELD
+        if x.mutable
+            Expr(:block, :(x.$FIELD = xval), :x)
+        else
+            :(@with x.$FIELD = xval)
+        end
     end
 end
 @generated function chfield(x, f::Function, xval)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,7 +117,7 @@ unzipped broadcast for arrays and tuples, e.g. `SWAP.([1,2,3], [4,5,6])` will do
 """
 unzipped_broadcast(f) = error("must provide at least one argument in broadcasting!")
 function unzipped_broadcast(f, arg::AbstractArray; kwargs...)
-    f.(arg)
+    arg .= f.(arg)
 end
 function unzipped_broadcast(f, arg::Tuple; kwargs...)
     f.(arg)

--- a/test/Core.jl
+++ b/test/Core.jl
@@ -10,3 +10,20 @@ using Test, NiLangCore
     println(MulEq(*))
     println(DivEq(/))
 end
+
+@testset "composite function" begin
+    @i function f1(x)
+        x.:1 += x.:2
+    end
+    @i function f2(x)
+        x.:2 += cos(x.:1)
+    end
+    @i function f3(x)
+        x.:1 ↔ x.:2
+    end
+    x = (2.0, 3.0)
+    y = (f3∘f2∘f1)(x)
+    z = (~(f3∘f2∘f1))(y)
+    @show x, z
+    @test all(x .≈ z)
+end

--- a/test/Core.jl
+++ b/test/Core.jl
@@ -11,6 +11,7 @@ using Test, NiLangCore
     println(DivEq(/))
 end
 
+@static if VERSION > v"1.5.100"
 @testset "composite function" begin
     @i function f1(x)
         x.:1 += x.:2
@@ -26,4 +27,5 @@ end
     z = (~(f3∘f2∘f1))(y)
     @show x, z
     @test all(x .≈ z)
+end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -48,3 +48,10 @@ end
     @test pop!(od) == (:c, 7)
     @test length(od) == 1
 end
+
+@testset "unzipped broadcast" begin
+    x = [1, 2, 3.0]
+    res = NiLangCore.unzipped_broadcast(exp, x)
+    @test res === x
+    @test res ≈ exp.([1, 2, 3.0])
+end


### PR DESCRIPTION
1. support reversing a composite function.
```julia
julia> ~(sin ∘ cos ∘ tan)
~tan ∘ ~cos ∘ ~sin
```
2. Fix the hehavior of unary broadcasting by making it inplace.